### PR TITLE
Add colorOnPrimary to custom theme colors

### DIFF
--- a/app/src/main/java/a/a/a/yq.java
+++ b/app/src/main/java/a/a/a/yq.java
@@ -97,6 +97,7 @@ public class yq {
     public final int colorAccent;
     public final int colorPrimary;
     public final int colorPrimaryDark;
+    public final int colorOnPrimary;
     public final int colorControlHighlight;
     public final int colorControlNormal;
     public final String versionCode;
@@ -212,6 +213,7 @@ public class yq {
         colorAccent = yB.a(metadata, ProjectFile.COLOR_ACCENT, getDefaultColor(ProjectFile.COLOR_ACCENT));
         colorPrimary = yB.a(metadata, ProjectFile.COLOR_PRIMARY, getDefaultColor(ProjectFile.COLOR_PRIMARY));
         colorPrimaryDark = yB.a(metadata, ProjectFile.COLOR_PRIMARY_DARK, getDefaultColor(ProjectFile.COLOR_PRIMARY_DARK));
+        colorOnPrimary = yB.a(metadata, ProjectFile.COLOR_ON_PRIMARY, getDefaultColor(ProjectFile.COLOR_ON_PRIMARY));
         colorControlHighlight = yB.a(metadata, ProjectFile.COLOR_CONTROL_HIGHLIGHT, getDefaultColor(ProjectFile.COLOR_CONTROL_HIGHLIGHT));
         colorControlNormal = yB.a(metadata, ProjectFile.COLOR_CONTROL_NORMAL, getDefaultColor(ProjectFile.COLOR_CONTROL_NORMAL));
 
@@ -989,6 +991,7 @@ public class yq {
         colorsFileBuilder.addColor("colorPrimary", String.format("#%06X", colorPrimary & 0xffffff));
         colorsFileBuilder.addColor("colorPrimaryDark", String.format("#%06X", colorPrimaryDark & 0xffffff));
         colorsFileBuilder.addColor("colorAccent", String.format("#%06X", colorAccent & 0xffffff));
+        colorsFileBuilder.addColor("colorOnPrimary", String.format("#%06X", colorOnPrimary & 0xffffff));
         colorsFileBuilder.addColor("colorControlHighlight", String.format("#%06X", colorControlHighlight & 0xffffff));
         colorsFileBuilder.addColor("colorControlNormal", String.format("#%06X", colorControlNormal & 0xffffff));
         return CommandBlock.applyCommands("colors.xml", colorsFileBuilder.toCode());
@@ -1019,8 +1022,7 @@ public class yq {
                     BuildSettings.SETTING_GENERIC_VALUE_FALSE).equals(BuildSettings.SETTING_GENERIC_VALUE_TRUE);
             XmlBuilderHelper stylesFileBuilder = new XmlBuilderHelper();
             stylesFileBuilder.addStyle("AppTheme", "Theme.MaterialComponents.Light.NoActionBar" + (useNewMaterialComponentsTheme ? "" : ".Bridge"));
-            // todo: add 'colorOnPrimary' to custom theme colors.
-            stylesFileBuilder.addItemToStyle("AppTheme", "colorOnPrimary", "@android:color/white");
+            stylesFileBuilder.addItemToStyle("AppTheme", "colorOnPrimary", "@color/colorOnPrimary");
             stylesFileBuilder.addItemToStyle("AppTheme", "colorPrimary", "@color/colorPrimary");
             stylesFileBuilder.addItemToStyle("AppTheme", "colorPrimaryDark", "@color/colorPrimaryDark");
             stylesFileBuilder.addItemToStyle("AppTheme", "colorAccent", "@color/colorAccent");

--- a/app/src/main/java/com/besome/sketch/projects/MyProjectSettingActivity.java
+++ b/app/src/main/java/com/besome/sketch/projects/MyProjectSettingActivity.java
@@ -59,8 +59,8 @@ import pro.sketchware.utility.SketchwareUtil;
 public class MyProjectSettingActivity extends BaseAppCompatActivity implements View.OnClickListener {
 
     private static final int REQUEST_CODE_CREATE_ICON = 200212;
-    private final String[] themeColorKeys = {"color_accent", "color_primary", "color_primary_dark", "color_control_highlight", "color_control_normal"};
-    private final String[] themeColorLabels = {"colorAccent", "colorPrimary", "colorPrimaryDark", "colorControlHighlight", "colorControlNormal"};
+    private final String[] themeColorKeys = {ProjectFile.COLOR_ACCENT, ProjectFile.COLOR_PRIMARY, ProjectFile.COLOR_PRIMARY_DARK, ProjectFile.COLOR_ON_PRIMARY, ProjectFile.COLOR_CONTROL_HIGHLIGHT, ProjectFile.COLOR_CONTROL_NORMAL};
+    private final String[] themeColorLabels = {"colorAccent", "colorPrimary", "colorPrimaryDark", "colorOnPrimary", "colorControlHighlight", "colorControlNormal"};
     private final int[] projectThemeColors = new int[themeColorKeys.length];
     public MyprojectSettingBinding binding;
     private PackageNameValidator projectPackageNameValidator;
@@ -130,8 +130,9 @@ public class MyProjectSettingActivity extends BaseAppCompatActivity implements V
         projectThemeColors[0] = getDefaultColor(ProjectFile.COLOR_ACCENT);
         projectThemeColors[1] = getDefaultColor(ProjectFile.COLOR_PRIMARY);
         projectThemeColors[2] = getDefaultColor(ProjectFile.COLOR_PRIMARY_DARK);
-        projectThemeColors[3] = getDefaultColor(ProjectFile.COLOR_CONTROL_HIGHLIGHT);
-        projectThemeColors[4] = getDefaultColor(ProjectFile.COLOR_CONTROL_NORMAL);
+        projectThemeColors[3] = getDefaultColor(ProjectFile.COLOR_ON_PRIMARY);
+        projectThemeColors[4] = getDefaultColor(ProjectFile.COLOR_CONTROL_HIGHLIGHT);
+        projectThemeColors[5] = getDefaultColor(ProjectFile.COLOR_CONTROL_NORMAL);
 
         for (int i = 0; i < themeColorKeys.length; i++) {
             ThemeColorView colorView = new ThemeColorView(this, i);
@@ -474,8 +475,9 @@ public class MyProjectSettingActivity extends BaseAppCompatActivity implements V
         projectThemeColors[0] = theme.colorAccent;
         projectThemeColors[1] = theme.colorPrimary;
         projectThemeColors[2] = theme.colorPrimaryDark;
-        projectThemeColors[3] = theme.colorControlHighlight;
-        projectThemeColors[4] = theme.colorControlNormal;
+        projectThemeColors[3] = theme.colorOnPrimary;
+        projectThemeColors[4] = theme.colorControlHighlight;
+        projectThemeColors[5] = theme.colorControlNormal;
 
         syncThemeColors();
     }

--- a/app/src/main/java/com/besome/sketch/projects/ThemeManager.java
+++ b/app/src/main/java/com/besome/sketch/projects/ThemeManager.java
@@ -16,15 +16,17 @@ public class ThemeManager {
         public int colorAccent;
         public int colorPrimary;
         public int colorPrimaryDark;
+        public int colorOnPrimary;
         public int colorControlHighlight;
         public int colorControlNormal;
 
         public ThemePreset(String name, int colorAccent, int colorPrimary, int colorPrimaryDark,
-                           int colorControlHighlight, int colorControlNormal) {
+                           int colorOnPrimary, int colorControlHighlight, int colorControlNormal) {
             this.name = name;
             this.colorAccent = colorAccent;
             this.colorPrimary = colorPrimary;
             this.colorPrimaryDark = colorPrimaryDark;
+            this.colorOnPrimary = colorOnPrimary;
             this.colorControlHighlight = colorControlHighlight;
             this.colorControlNormal = colorControlNormal;
         }
@@ -32,40 +34,40 @@ public class ThemeManager {
 
     private static final ThemePreset[] THEME_PRESETS = {
             new ThemePreset("Material Purple",
-                    0xFF03DAC5, 0xFF6200EE, 0xFF3700B3, 0xFFE8EAF6, 0xFFBDBDBD),
+                    0xFF03DAC5, 0xFF6200EE, 0xFF3700B3, 0xFFFFFFFF, 0xFFE8EAF6, 0xFFBDBDBD),
 
             new ThemePreset("Material Blue",
-                    0xFF03DAC5, 0xFF1976D2, 0xFF0D47A1, 0xFFE3F2FD, 0xFFBDBDBD),
+                    0xFF03DAC5, 0xFF1976D2, 0xFF0D47A1, 0xFFFFFFFF, 0xFFE3F2FD, 0xFFBDBDBD),
 
             new ThemePreset("Material Green",
-                    0xFF03DAC5, 0xFF388E3C, 0xFF1B5E20, 0xFFE8F5E8, 0xFFBDBDBD),
+                    0xFF03DAC5, 0xFF388E3C, 0xFF1B5E20, 0xFFFFFFFF, 0xFFE8F5E8, 0xFFBDBDBD),
 
             new ThemePreset("Material Red",
-                    0xFF03DAC5, 0xFFD32F2F, 0xFFB71C1C, 0xFFFFEBEE, 0xFFBDBDBD),
+                    0xFF03DAC5, 0xFFD32F2F, 0xFFB71C1C, 0xFFFFFFFF, 0xFFFFEBEE, 0xFFBDBDBD),
 
             new ThemePreset("Material Orange",
-                    0xFF03DAC5, 0xFFF57C00, 0xFFE65100, 0xFFFFF3E0, 0xFFBDBDBD),
+                    0xFF03DAC5, 0xFFF57C00, 0xFFE65100, 0xFFFFFFFF, 0xFFFFF3E0, 0xFFBDBDBD),
 
             new ThemePreset("Material Teal",
-                    0xFF03DAC5, 0xFF00796B, 0xFF004D40, 0xFFE0F2F1, 0xFFBDBDBD),
+                    0xFF03DAC5, 0xFF00796B, 0xFF004D40, 0xFFFFFFFF, 0xFFE0F2F1, 0xFFBDBDBD),
 
             new ThemePreset("Material Indigo",
-                    0xFF03DAC5, 0xFF3F51B5, 0xFF1A237E, 0xFFE8EAF6, 0xFFBDBDBD),
+                    0xFF03DAC5, 0xFF3F51B5, 0xFF1A237E, 0xFFFFFFFF, 0xFFE8EAF6, 0xFFBDBDBD),
 
             new ThemePreset("Material Pink",
-                    0xFF03DAC5, 0xFFC2185B, 0xFF880E4F, 0xFFFCE4EC, 0xFFBDBDBD),
+                    0xFF03DAC5, 0xFFC2185B, 0xFF880E4F, 0xFFFFFFFF, 0xFFFCE4EC, 0xFFBDBDBD),
 
             new ThemePreset("Dark Purple",
-                    0xFF03DAC5, 0xFFBB86FC, 0xFF3700B3, 0xFF1F1F1F, 0xFF666666),
+                    0xFF03DAC5, 0xFFBB86FC, 0xFF3700B3, 0xFF000000, 0xFF1F1F1F, 0xFF666666),
 
             new ThemePreset("Dark Blue",
-                    0xFF03DAC5, 0xFF64B5F6, 0xFF1976D2, 0xFF1F1F1F, 0xFF666666),
+                    0xFF03DAC5, 0xFF64B5F6, 0xFF1976D2, 0xFF000000, 0xFF1F1F1F, 0xFF666666),
 
             new ThemePreset("Light Purple",
-                    0xFF03DAC5, 0xFF6200EE, 0xFF3700B3, 0xFFF3E5F5, 0xFFE1BEE7),
+                    0xFF03DAC5, 0xFF6200EE, 0xFF3700B3, 0xFFFFFFFF, 0xFFF3E5F5, 0xFFE1BEE7),
 
             new ThemePreset("Light Blue",
-                    0xFF03DAC5, 0xFF1976D2, 0xFF0D47A1, 0xFFE3F2FD, 0xFFBBDEFB)
+                    0xFF03DAC5, 0xFF1976D2, 0xFF0D47A1, 0xFFFFFFFF, 0xFFE3F2FD, 0xFFBBDEFB)
     };
 
     public static ThemePreset[] getThemePresets() {
@@ -90,11 +92,13 @@ public class ThemeManager {
         hsv[2] = 0.8f + random.nextFloat() * 0.2f;
         int accentColor = Color.HSVToColor(hsv);
 
+        int colorOnPrimary = isColorDark(primaryColor) ? Color.WHITE : Color.BLACK;
+
         int controlHighlightColor = lightenColor(primaryColor, 0.9f);
         int controlNormalColor = Color.GRAY;
 
         return new ThemePreset("Random Theme", accentColor, primaryColor, primaryDarkColor,
-                controlHighlightColor, controlNormalColor);
+                colorOnPrimary, controlHighlightColor, controlNormalColor);
     }
 
     public static ThemePreset getDefault() {
@@ -103,6 +107,7 @@ public class ThemeManager {
                 getDefaultColor(ProjectFile.COLOR_ACCENT),
                 getDefaultColor(ProjectFile.COLOR_PRIMARY),
                 getDefaultColor(ProjectFile.COLOR_PRIMARY_DARK),
+                getDefaultColor(ProjectFile.COLOR_ON_PRIMARY),
                 getDefaultColor(ProjectFile.COLOR_CONTROL_HIGHLIGHT),
                 getDefaultColor(ProjectFile.COLOR_CONTROL_NORMAL));
     }
@@ -120,6 +125,11 @@ public class ThemeManager {
         hsv[2] = Math.min(1.0f, hsv[2] + factor);
         hsv[1] = Math.max(0.0f, hsv[1] - factor * 0.5f);
         return Color.HSVToColor(hsv);
+    }
+
+    private static boolean isColorDark(int color) {
+        double darkness = 1 - (0.299 * Color.red(color) + 0.587 * Color.green(color) + 0.114 * Color.blue(color)) / 255;
+        return darkness >= 0.5;
     }
 
 } 

--- a/app/src/main/java/mod/hey/studios/util/ProjectFile.java
+++ b/app/src/main/java/mod/hey/studios/util/ProjectFile.java
@@ -11,6 +11,7 @@ public class ProjectFile {
     public static final String COLOR_ACCENT = "color_accent";
     public static final String COLOR_PRIMARY = "color_primary";
     public static final String COLOR_PRIMARY_DARK = "color_primary_dark";
+    public static final String COLOR_ON_PRIMARY = "color_on_primary";
     public static final String COLOR_CONTROL_HIGHLIGHT = "color_control_highlight";
     public static final String COLOR_CONTROL_NORMAL = "color_control_normal";
 
@@ -47,6 +48,7 @@ public class ProjectFile {
             return switch (color) {
                 case "color_primary_dark" ->
                         SketchApplication.getContext().getColor(android.R.color.system_accent1_500);
+                case "color_on_primary" -> Color.WHITE;
                 case "color_control_highlight" ->
                         SketchApplication.getContext().getColor(android.R.color.system_accent1_100);
                 default ->
@@ -56,6 +58,7 @@ public class ProjectFile {
             // For Android versions below 12: use static fallback colors
             return switch (color) {
                 case "color_primary_dark" -> Color.parseColor("#ff1976d2");
+                case "color_on_primary" -> Color.WHITE;
                 case "color_control_highlight" -> Color.parseColor("#202196f3");
                 default -> Color.parseColor("#ff2196f3");
             };

--- a/app/src/main/java/pro/sketchware/activities/resourceseditor/components/fragments/ColorsEditor.java
+++ b/app/src/main/java/pro/sketchware/activities/resourceseditor/components/fragments/ColorsEditor.java
@@ -135,6 +135,7 @@ public class ColorsEditor extends Fragment {
         defaultColors.put("colorAccent", ProjectFile.COLOR_ACCENT);
         defaultColors.put("colorPrimary", ProjectFile.COLOR_PRIMARY);
         defaultColors.put("colorPrimaryDark", ProjectFile.COLOR_PRIMARY_DARK);
+        defaultColors.put("colorOnPrimary", ProjectFile.COLOR_ON_PRIMARY);
         defaultColors.put("colorControlHighlight", ProjectFile.COLOR_CONTROL_HIGHLIGHT);
         defaultColors.put("colorControlNormal", ProjectFile.COLOR_CONTROL_NORMAL);
 


### PR DESCRIPTION
Added support for the 'colorOnPrimary' theme attribute across the application. This includes constant definition, default value handling, XML resource generation, theme preset updates, and UI integration for user editing.

---
*PR created automatically by Jules for task [13449133685283529550](https://jules.google.com/task/13449133685283529550) started by @itarunpatil*