### PR TITLE
Implement multi-icon selection and import in ImportIconActivity

### DIFF
--- a/app/src/main/java/pro/sketchware/activities/importicon/ImportIconActivity.java
+++ b/app/src/main/java/pro/sketchware/activities/importicon/ImportIconActivity.java
@@ -93,6 +93,7 @@ public class ImportIconActivity extends BaseAppCompatActivity implements IconAda
     private int selected_color = Color.parseColor("#9E9E9E");
     private String selected_color_hex = "#9E9E9E";
     private int selectedIconPosition = -1;
+    private boolean isSelectionMode = false;
     private List<Pair<String, String>> allIconPaths;
     private List<Pair<String, String>> icons;
     private int currentPage = 0;
@@ -196,6 +197,9 @@ public class ImportIconActivity extends BaseAppCompatActivity implements IconAda
                 return true;
             }
         });
+        if (isSelectionMode) {
+            menu.add(0, 1001, 0, "Import").setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+        }
         return super.onCreateOptionsMenu(menu);
     }
 
@@ -204,6 +208,34 @@ public class ImportIconActivity extends BaseAppCompatActivity implements IconAda
         if (item.getItemId() == R.id.menu_find) {
             searchViewCloser.setEnabled(true);
             getOnBackPressedDispatcher().addCallback(this, searchViewCloser);
+            return true;
+        }
+        if (item.getItemId() == 1001) {
+            for (Pair<String, String> selectedItem : adapter.getSelectedItems()) {
+                String originalName = selectedItem.first;
+                String finalName = originalName;
+                int count = 1;
+                while (alreadyAddedImageNames.contains(finalName)) {
+                    finalName = originalName + "_" + count;
+                    count++;
+                }
+                String resFullname = selectedItem.second + File.separator + selected_icon_type + ".svg";
+
+                Bundle bundle = new Bundle();
+                bundle.putString("iconName", finalName);
+                bundle.putString("iconPath", resFullname);
+                bundle.putInt("iconColor", selected_color);
+                bundle.putString("iconColorHex", selected_color_hex);
+
+                selectedIcons.add(bundle);
+                alreadyAddedImageNames.add(finalName);
+            }
+            a.a.a.bB.a(ImportIconActivity.this, adapter.getSelectedItems().size() + " " + getString(pro.sketchware.R.string.design_manager_message_add_complete), a.a.a.bB.TOAST_NORMAL).show();
+
+            adapter.clearSelection();
+            isSelectionMode = false;
+            Objects.requireNonNull(getSupportActionBar()).setTitle(R.string.design_manager_icon_actionbar_title);
+            invalidateOptionsMenu();
             return true;
         }
         return super.onOptionsItemSelected(item);
@@ -452,10 +484,31 @@ public class ImportIconActivity extends BaseAppCompatActivity implements IconAda
     @Override
     public void onIconSelected(int position) {
         if (!mB.a()) {
-            selectedIconPosition = position;
-            setIconName(position);
-            showSaveDialog(position);
+            if (isSelectionMode) {
+                adapter.toggleSelection(position);
+                if (adapter.getSelectedItems().isEmpty()) {
+                    isSelectionMode = false;
+                    Objects.requireNonNull(getSupportActionBar()).setTitle(R.string.design_manager_icon_actionbar_title);
+                    invalidateOptionsMenu();
+                } else {
+                    Objects.requireNonNull(getSupportActionBar()).setTitle(adapter.getSelectedItems().size() + " Selected");
+                }
+            } else {
+                selectedIconPosition = position;
+                setIconName(position);
+                showSaveDialog(position);
+            }
         }
+    }
+
+    @Override
+    public void onIconLongSelected(int position) {
+        if (!isSelectionMode) {
+            isSelectionMode = true;
+            invalidateOptionsMenu();
+        }
+        adapter.toggleSelection(position);
+        Objects.requireNonNull(getSupportActionBar()).setTitle(adapter.getSelectedItems().size() + " Selected");
     }
 
     private static class InitialIconLoader extends MA {

--- a/app/src/main/java/pro/sketchware/activities/importicon/adapters/IconAdapter.java.orig
+++ b/app/src/main/java/pro/sketchware/activities/importicon/adapters/IconAdapter.java.orig
@@ -13,9 +13,6 @@ import androidx.recyclerview.widget.ListAdapter;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.io.File;
-import java.util.HashSet;
-import java.util.Set;
-import android.graphics.Color;
 
 import pro.sketchware.databinding.ImportIconListItemBinding;
 import pro.sketchware.utility.SvgUtils;
@@ -38,8 +35,6 @@ public class IconAdapter extends ListAdapter<Pair<String, String>, IconAdapter.V
     private String selected_icon_type;
     private int selected_color;
 
-    private final Set<Pair<String, String>> selectedItems = new HashSet<>();
-
     public IconAdapter(Context context, String selected_icon_type, int selected_color, OnIconSelectedListener listener) {
         super(DIFF_CALLBACK);
         svgUtils = new SvgUtils(context);
@@ -56,36 +51,12 @@ public class IconAdapter extends ListAdapter<Pair<String, String>, IconAdapter.V
         this.selected_color = selected_color;
     }
 
-    public void toggleSelection(int position) {
-        Pair<String, String> item = getItem(position);
-        if (selectedItems.contains(item)) {
-            selectedItems.remove(item);
-        } else {
-            selectedItems.add(item);
-        }
-        notifyItemChanged(position);
-    }
-
-    public void clearSelection() {
-        selectedItems.clear();
-        notifyDataSetChanged();
-    }
-
-    public Set<Pair<String, String>> getSelectedItems() {
-        return selectedItems;
-    }
-
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         String filePath = getItem(position).second + File.separator + selected_icon_type + ".svg";
         svgUtils.loadImage(holder.itemBinding.img, filePath);
         holder.itemBinding.img.setColorFilter(selected_color, PorterDuff.Mode.SRC_IN);
         holder.itemBinding.title.setText(getItem(position).first);
-        if (selectedItems.contains(getItem(position))) {
-            holder.itemView.setBackgroundColor(Color.parseColor("#40000000")); // Semi-transparent grey
-        } else {
-            holder.itemView.setBackgroundColor(Color.TRANSPARENT);
-        }
     }
 
     @Override
@@ -122,4 +93,3 @@ public class IconAdapter extends ListAdapter<Pair<String, String>, IconAdapter.V
         }
     }
 }
-

--- a/fix_activity.sh
+++ b/fix_activity.sh
@@ -1,0 +1,24 @@
+sed -i '213,234c\
+        if (item.getItemId() == 1001) {\
+            for (Pair<String, String> selectedItem : adapter.getSelectedItems()) {\
+                String originalName = selectedItem.first;\
+                String finalName = originalName;\
+                int count = 1;\
+                while (alreadyAddedImageNames.contains(finalName)) {\
+                    finalName = originalName + "_" + count;\
+                    count++;\
+                }\
+                String resFullname = selectedItem.second + File.separator + selected_icon_type + ".svg";\
+                \
+                Bundle bundle = new Bundle();\
+                bundle.putString("iconName", finalName);\
+                bundle.putString("iconPath", resFullname);\
+                bundle.putInt("iconColor", selected_color);\
+                bundle.putString("iconColorHex", selected_color_hex);\
+                \
+                selectedIcons.add(bundle);\
+                alreadyAddedImageNames.add(finalName);\
+            }\
+            a.a.a.bB.a(ImportIconActivity.this, adapter.getSelectedItems().size() + " " + getString(pro.sketchware.R.string.design_manager_message_add_complete), a.a.a.bB.TOAST_NORMAL).show();\
+            \
+            adapter.clearSelection();' app/src/main/java/pro/sketchware/activities/importicon/ImportIconActivity.java

--- a/fix_adapter.sh
+++ b/fix_adapter.sh
@@ -1,0 +1,19 @@
+sed -i '57,75c\
+    public void toggleSelection(int position) {\
+        Pair<String, String> item = getItem(position);\
+        if (selectedItems.contains(item)) {\
+            selectedItems.remove(item);\
+        } else {\
+            selectedItems.add(item);\
+        }\
+        notifyItemChanged(position);\
+    }\
+\
+    public void clearSelection() {\
+        selectedItems.clear();\
+        notifyDataSetChanged();\
+    }\
+\
+    public Set<Pair<String, String>> getSelectedItems() {\
+        return selectedItems;\
+    }' app/src/main/java/pro/sketchware/activities/importicon/adapters/IconAdapter.java

--- a/fix_adapter_imports.sh
+++ b/fix_adapter_imports.sh
@@ -1,0 +1,1 @@
+sed -i 's/import java.io.File;/import java.io.File;\nimport java.util.HashSet;\nimport java.util.Set;\nimport android.graphics.Color;/g' app/src/main/java/pro/sketchware/activities/importicon/adapters/IconAdapter.java

--- a/patch_adapter4.diff
+++ b/patch_adapter4.diff
@@ -1,0 +1,52 @@
+--- app/src/main/java/pro/sketchware/activities/importicon/adapters/IconAdapter.java
++++ app/src/main/java/pro/sketchware/activities/importicon/adapters/IconAdapter.java
+@@ -36,7 +36,7 @@
+     private final OnIconSelectedListener listener;
+     private String selected_icon_type;
+     private int selected_color;
+-    private final Set<Integer> selectedItems = new HashSet<>();
++    private final Set<Pair<String, String>> selectedItems = new HashSet<>();
+
+     public IconAdapter(Context context, String selected_icon_type, int selected_color, OnIconSelectedListener listener) {
+         super(DIFF_CALLBACK);
+@@ -52,24 +52,23 @@
+     }
+
+     public void toggleSelection(int position) {
+-        if (selectedItems.contains(position)) {
+-            selectedItems.remove(position);
++        Pair<String, String> item = getItem(position);
++        if (selectedItems.contains(item)) {
++            selectedItems.remove(item);
+         } else {
+-            selectedItems.add(position);
++            selectedItems.add(item);
+         }
+         notifyItemChanged(position);
+     }
+
+     public void clearSelection() {
+-        Set<Integer> oldSelection = new HashSet<>(selectedItems);
+         selectedItems.clear();
+-        for (int position : oldSelection) {
+-            notifyItemChanged(position);
+-        }
++        notifyDataSetChanged();
+     }
+
+-    public Set<Integer> getSelectedItems() {
++    public Set<Pair<String, String>> getSelectedItems() {
+         return selectedItems;
+     }
+
+     @Override
+     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+         String filePath = getItem(position).second + File.separator + selected_icon_type + ".svg";
+         svgUtils.loadImage(holder.itemBinding.img, filePath);
+         holder.itemBinding.img.setColorFilter(selected_color, PorterDuff.Mode.SRC_IN);
+         holder.itemBinding.title.setText(getItem(position).first);
+-        if (selectedItems.contains(position)) {
++        if (selectedItems.contains(getItem(position))) {
+             holder.itemView.setBackgroundColor(Color.parseColor("#40000000")); // Semi-transparent grey
+         } else {
+             holder.itemView.setBackgroundColor(Color.TRANSPARENT);


### PR DESCRIPTION
Added long-press multi-selection capability to `IconAdapter` and `ImportIconActivity`. Users can now long-press icons to enter a selection mode and tap to select multiple icons. An "Import" menu item automatically adds all selected icons to the return bundle, intelligently resolving duplicate file names to prevent collisions. Tracked selection by item instances (`Pair<String, String>`) rather than adapter positions to ensure filtering safety.