### PR TITLE
⚡ Optimize View Recycling in AndroidManifestInjection

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,9 @@
+I was unable to show a meaningful performance improvement because measuring UI rendering times and object allocation within an Android context requires an active emulator or instrumented testing framework, which are not currently set up in this environment.
+
+However, the optimization resolves a known Android architectural performance anti-pattern.
+
+What: The `getView()` method in `AndroidManifestInjection.java`'s adapter was modified to reuse the `convertView` passed into it.
+
+Why: Previously, a new `CustomAttributeView` was being instantiated every single time `getView` was called. For large lists, this caused significant overhead from inflating/instantiating views rapidly during scrolling, which causes frame drops and memory churn. Reusing `convertView` if it's not null eliminates this overhead, reusing the same view object to just display different data, which is standard Android practice.
+
+Measured Improvement: Could not be quantified locally due to framework dependencies, but theoretically reduces `CustomAttributeView` allocations to exactly the number of rows visible on the screen plus one, as opposed to linearly matching the total count of list items multiplied by scrolling interactions.

--- a/app/src/main/java/mod/hilal/saif/activities/android_manifest/AndroidManifestInjection.java
+++ b/app/src/main/java/mod/hilal/saif/activities/android_manifest/AndroidManifestInjection.java
@@ -454,7 +454,12 @@ public class AndroidManifestInjection extends BaseAppCompatActivity {
 
         @Override
         public View getView(int position, View convertView, ViewGroup parent) {
-            CustomAttributeView attributeView = new CustomAttributeView(parent.getContext());
+            CustomAttributeView attributeView;
+            if (convertView == null) {
+                attributeView = new CustomAttributeView(parent.getContext());
+            } else {
+                attributeView = (CustomAttributeView) convertView;
+            }
 
             attributeView.getImageView().setVisibility(View.GONE);
             attributeView.getTextView().setText((String) activitiesListMap.get(position).get("act_name"));


### PR DESCRIPTION
💡 **What:** Modified the `getView()` method in `AndroidManifestInjection.java`'s internal adapter to properly recycle list item views by reusing `convertView` instead of re-instantiating `CustomAttributeView` unconditionally.

🎯 **Why:** Previously, rapid instantiation of views during ListAdapter scrolling caused unnecessary view inflation overhead and GC churn. By checking for a `null` `convertView`, we follow standard Android adapter practices and recycle view hierarchies.

📊 **Measured Improvement:** I was unable to show a meaningful performance improvement because measuring UI rendering times and object allocation within an Android context requires an active emulator or instrumented testing framework, which are not currently set up in this environment. However, theoretically, it reduces object allocations from $O(N)$ (where $N$ is total scrolling items processed) to $O(V)$ (where $V$ is visible rows plus one), drastically reducing CPU load during list scrolling.

---
*PR created automatically by Jules for task [7847312761058240647](https://jules.google.com/task/7847312761058240647) started by @itarunpatil*