### PR TITLE
⚡ Performance Improvement: Implement ViewHolder in BlocksManagerDetailsActivity

### DIFF
--- a/app/src/main/java/mod/hilal/saif/activities/tools/BlocksManagerDetailsActivity.java
+++ b/app/src/main/java/mod/hilal/saif/activities/tools/BlocksManagerDetailsActivity.java
@@ -539,21 +539,43 @@ public class BlocksManagerDetailsActivity extends BaseAppCompatActivity {
             return position;
         }
 
+        private class ViewHolder {
+            LinearLayout background;
+            TextView name;
+            TextView spec;
+            CardView upLayout;
+            CardView downLayout;
+            LinearLayout down;
+            LinearLayout up;
+        }
+
         @Override
         public View getView(int position, View convertView, ViewGroup parent) {
+            ViewHolder holder;
             if (convertView == null) {
                 convertView = getLayoutInflater().inflate(R.layout.block_customview, parent, false);
+                holder = new ViewHolder();
+                holder.background = convertView.findViewById(R.id.background);
+                holder.name = convertView.findViewById(R.id.name);
+                holder.spec = convertView.findViewById(R.id.spec);
+                holder.upLayout = convertView.findViewById(R.id.up_layout);
+                holder.downLayout = convertView.findViewById(R.id.down_layout);
+                holder.down = convertView.findViewById(R.id.down);
+                holder.up = convertView.findViewById(R.id.up);
+                convertView.setTag(holder);
+            } else {
+                holder = (ViewHolder) convertView.getTag();
             }
 
             HashMap<String, Object> block = blocks.get(position);
 
-            LinearLayout background = convertView.findViewById(R.id.background);
-            TextView name = convertView.findViewById(R.id.name);
-            TextView spec = convertView.findViewById(R.id.spec);
-            CardView upLayout = convertView.findViewById(R.id.up_layout);
-            CardView downLayout = convertView.findViewById(R.id.down_layout);
-            LinearLayout down = convertView.findViewById(R.id.down);
-            LinearLayout up = convertView.findViewById(R.id.up);
+            LinearLayout background = holder.background;
+            TextView name = holder.name;
+            TextView spec = holder.spec;
+            CardView upLayout = holder.upLayout;
+            CardView downLayout = holder.downLayout;
+            LinearLayout down = holder.down;
+            LinearLayout up = holder.up;
 
             if (mode.equals("normal")) {
                 downLayout.setVisibility(View.GONE);


### PR DESCRIPTION
💡 **What:**
Implemented the ViewHolder pattern in the `Adapter.getView` method within `BlocksManagerDetailsActivity.java`. Added a `ViewHolder` inner class to cache the looked-up views (`background`, `name`, `spec`, `upLayout`, `downLayout`, `down`, `up`) and assigned it via `convertView.setTag(holder)`. When `convertView` is recycled, we retrieve the cached views via `getTag()`.

🎯 **Why:**
Prior to this change, `convertView.findViewById(...)` was executed for every bound item, whether newly inflated or recycled. `findViewById` is relatively expensive because it traverses the view hierarchy. By implementing the ViewHolder pattern, we eliminate these redundant lookups, solving a classic Android ListView performance issue and making scrolling much smoother while lowering CPU and memory churn.

📊 **Measured Improvement:**
Since this is an optimization of Android framework classes (`View`, `ViewGroup`, `LayoutInflater`), standard JVM local measurements (where the Android runtime is mocked/stubbed) do not reliably profile or represent the on-device performance of inflation vs recycling. However, this is universally recognized as an essential Android optimization that changes view binding complexity from O(N) (N = number of views in hierarchy) to O(1) constant time, offering a mathematically guaranteed improvement. No external baseline measurement could be generated without a physical Android device or emulator. The code successfully builds without regressions.

---
*PR created automatically by Jules for task [2798952618380196517](https://jules.google.com/task/2798952618380196517) started by @itarunpatil*