### PR TITLE
🧹 Replace e.printStackTrace() with proper logging in Network.java

### DIFF
--- a/app/src/main/java/pro/sketchware/utility/Network.java
+++ b/app/src/main/java/pro/sketchware/utility/Network.java
@@ -2,6 +2,7 @@ package pro.sketchware.utility;
 
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 
@@ -18,6 +19,8 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 
 public class Network {
+
+    private static final String TAG = "Network";
 
     private final OkHttpClient client;
 
@@ -56,7 +59,7 @@ public class Network {
         client.newCall(request).enqueue(new Callback() {
             @Override
             public void onFailure(@NonNull Call call, @NonNull IOException e) {
-                e.printStackTrace();
+                Log.e(TAG, "Network request failed", e);
                 runOnUiThread(() -> handler.handleResponse(null));
             }
 
@@ -66,6 +69,7 @@ public class Network {
                     String responseBody = response.body() != null ? response.body().string() : null;
                     runOnUiThread(() -> handler.handleResponse(responseBody));
                 } catch (IOException e) {
+                    Log.e(TAG, "Error reading response body", e);
                     runOnUiThread(() -> handler.handleResponse(null));
                 }
             }


### PR DESCRIPTION
🎯 **What:** Replaced `e.printStackTrace()` with `Log.e()` for better logging practices in `pro.sketchware.utility.Network`.
💡 **Why:** Hardcoded print statements write to standard error and aren't properly captured by Android's logcat tools with expected severities and tags.
✅ **Verification:** Verified compilation using `./gradlew compileDebugJavaWithJavac`. Also successfully passed code review.
✨ **Result:** Improved codebase maintainability by centralizing and categorizing exception logs.

---
*PR created automatically by Jules for task [15238772877979355862](https://jules.google.com/task/15238772877979355862) started by @itarunpatil*