### PR TITLE
🧹 Code Health: Remove unused `android.view.Gravity` import in `PropertyResourceItem.java`

### DIFF
--- a/app/src/main/java/com/besome/sketch/editor/property/PropertyResourceItem.java
+++ b/app/src/main/java/com/besome/sketch/editor/property/PropertyResourceItem.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.graphics.Color;
 import android.net.Uri;
 import android.text.Editable;
-import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;


### PR DESCRIPTION
🎯 **What:** Removed unused import `android.view.Gravity` from `app/src/main/java/com/besome/sketch/editor/property/PropertyResourceItem.java`.
💡 **Why:** Unused imports can be safely removed to improve code cleanliness, maintainability, and readability.
✅ **Verification:**
- Ran `./gradlew compileDebugJavaWithJavac` and confirmed no compilation errors were introduced.
- Successfully ran `./gradlew test` and verified that no existing unit tests were broken (after temporarily providing a missing test dependency context on the classpath).
✨ **Result:** A cleaner file with no unused imports.

---
*PR created automatically by Jules for task [9384560848450698199](https://jules.google.com/task/9384560848450698199) started by @itarunpatil*