### PR TITLE
🧹 Remove unused import: android.os.Environment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,6 +97,7 @@ dependencies {
     implementation libs.zipalign.java
 
     implementation libs.gson
+    testImplementation 'junit:junit:4.13.2'
     implementation libs.scpkix.jdk15on
 
     implementation libs.markwon

--- a/app/src/main/java/pro/sketchware/importer/AndroidStudioProjectImporter.java
+++ b/app/src/main/java/pro/sketchware/importer/AndroidStudioProjectImporter.java
@@ -11,7 +11,6 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.net.Uri;
-import android.os.Environment;
 import android.text.TextUtils;
 import android.util.Log;
 


### PR DESCRIPTION
🎯 **What:** Removed unused `android.os.Environment` import from `AndroidStudioProjectImporter.java` and added the missing `junit` dependency so that unit tests can compile.
💡 **Why:** Unused imports clutter the file and can slightly increase mental overhead for readers. Keeping code clean improves overall maintainability. Test dependencies ensure developers can run `test`.
✅ **Verification:** Ran `./gradlew check` and `./gradlew test` to ensure functionality wasn't broken (with a couple tests compiling successfully now).
✨ **Result:** Cleaned up code file and functioning tests!

---
*PR created automatically by Jules for task [754676332986954239](https://jules.google.com/task/754676332986954239) started by @itarunpatil*