### PR TITLE
🧹 Remove unused ContextCompat import from BaseAppCompatActivity

### DIFF
--- a/app/src/main/java/com/besome/sketch/lib/base/BaseAppCompatActivity.java
+++ b/app/src/main/java/com/besome/sketch/lib/base/BaseAppCompatActivity.java
@@ -15,7 +15,6 @@ import androidx.activity.EdgeToEdge;
 import androidx.activity.SystemBarStyle;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.content.ContextCompat;
 import androidx.core.view.WindowInsetsCompat;
 
 import com.besome.sketch.lib.ui.LoadingDialog;


### PR DESCRIPTION
🎯 **What:** Removed an unused import (`androidx.core.content.ContextCompat`) from `app/src/main/java/com/besome/sketch/lib/base/BaseAppCompatActivity.java`.
💡 **Why:** This improves code cleanliness by removing unnecessary imports, which can help slightly with compilation overhead and maintainability.
✅ **Verification:** Verified by compiling the app using `./gradlew compileDebugJavaWithJavac`. Tests and lint check currently fail on the master branch independently of this change. Code review gave a #Correct# rating.
✨ **Result:** A cleaner file with no unused imports.

---
*PR created automatically by Jules for task [802690308130340740](https://jules.google.com/task/802690308130340740) started by @itarunpatil*