### PR TITLE
Check Superfluous Regs Remove in LocalList.java

### DIFF
--- a/app/src/main/java/mod/agus/jcoderz/dx/dex/code/LocalList.java
+++ b/app/src/main/java/mod/agus/jcoderz/dx/dex/code/LocalList.java
@@ -889,7 +889,7 @@ public final class LocalList extends FixedSizeList {
                      * update it.
                      */
                     result.set(endAt, endEntry.withDisposition(disposition));
-                    regs.remove(spec); // TODO: Is this line superfluous?
+
                     return;
                 }
             }


### PR DESCRIPTION
This PR addresses the issue of checking if `regs.remove(spec)` in `LocalList.java:892` is superfluous.
It turns out it is, because when `addOrUpdateEnd` is updating the disposition of a previous end entry, the `spec` must have already been removed from `regs` when the original end entry was added.
The superfluous line has been deleted.
I ran compilation and verified everything builds successfully. Code review confirmed this is safe and correct.

---
*PR created automatically by Jules for task [11716043694262254044](https://jules.google.com/task/11716043694262254044) started by @itarunpatil*