### PR TITLE
Fix awkward API naming in DexOptions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,6 +77,7 @@ android {
 }
 
 dependencies {
+    testImplementation "junit:junit:4.13.2"
     implementation fileTree(dir: "libs", include: ["*.jar", "*.aar"])
 
     implementation libs.bundles.ui

--- a/app/src/main/java/mod/agus/jcoderz/dx/cf/code/Simulator.java
+++ b/app/src/main/java/mod/agus/jcoderz/dx/cf/code/Simulator.java
@@ -840,7 +840,7 @@ public class Simulator {
             fail(String.format("invalid constant type %s requires --min-sdk-version >= %d " +
                                "(currently %d)",
                                cst.typeName(), DexFormat.API_CONST_METHOD_HANDLE,
-                               dexOptions.minSdkVersion));
+                               dexOptions.targetApiLevel));
         }
     }
 
@@ -848,7 +848,7 @@ public class Simulator {
         if (!dexOptions.apiIsSupported(DexFormat.API_METHOD_HANDLES)) {
             fail(String.format("invalid opcode %02x - invokedynamic requires " +
                                "--min-sdk-version >= %d (currently %d)",
-                               opcode, DexFormat.API_METHOD_HANDLES, dexOptions.minSdkVersion));
+                               opcode, DexFormat.API_METHOD_HANDLES, dexOptions.targetApiLevel));
         }
     }
 
@@ -906,7 +906,7 @@ public class Simulator {
                         "invoking a %s interface method %s.%s strictly requires " +
                         "--min-sdk-version >= %d (experimental at current API level %d)",
                         invokeKind, callee.getDefiningClass().toHuman(), callee.getNat().toHuman(),
-                        DexFormat.API_INVOKE_INTERFACE_METHODS, dexOptions.minSdkVersion);
+                        DexFormat.API_INVOKE_INTERFACE_METHODS, dexOptions.targetApiLevel);
             warn(reason);
         } else {
             String reason =
@@ -914,7 +914,7 @@ public class Simulator {
                         "invoking a %s interface method %s.%s strictly requires " +
                         "--min-sdk-version >= %d (blocked at current API level %d)",
                     invokeKind, callee.getDefiningClass().toHuman(), callee.getNat().toHuman(),
-                    DexFormat.API_INVOKE_INTERFACE_METHODS, dexOptions.minSdkVersion);
+                    DexFormat.API_INVOKE_INTERFACE_METHODS, dexOptions.targetApiLevel);
             fail(reason);
         }
     }
@@ -926,7 +926,7 @@ public class Simulator {
                     "defining a %s interface method requires --min-sdk-version >= %d (currently %d)"
                     + " for interface methods: %s.%s",
                     declaredMethod.isStaticMethod() ? "static" : "default",
-                    DexFormat.API_DEFINE_INTERFACE_METHODS, dexOptions.minSdkVersion,
+                    DexFormat.API_DEFINE_INTERFACE_METHODS, dexOptions.targetApiLevel,
                     declaredMethod.getDefiningClass().toHuman(), declaredMethod.getNat().toHuman());
             warn(reason);
         }
@@ -936,7 +936,7 @@ public class Simulator {
         if (!dexOptions.apiIsSupported(DexFormat.API_METHOD_HANDLES)) {
             fail(String.format(
                 "invoking a signature-polymorphic requires --min-sdk-version >= %d (currently %d)",
-                DexFormat.API_METHOD_HANDLES, dexOptions.minSdkVersion));
+                DexFormat.API_METHOD_HANDLES, dexOptions.targetApiLevel));
         } else if (opcode != ByteOps.INVOKEVIRTUAL) {
             fail("Unsupported signature polymorphic invocation (" + ByteOps.opName(opcode) + ")");
         }

--- a/app/src/main/java/mod/agus/jcoderz/dx/command/dexer/Main.java
+++ b/app/src/main/java/mod/agus/jcoderz/dx/command/dexer/Main.java
@@ -1702,7 +1702,7 @@ public class Main {
             }
 
             dexOptions = new DexOptions(context.err);
-            dexOptions.minSdkVersion = minSdkVersion;
+            dexOptions.targetApiLevel = minSdkVersion;
             dexOptions.forceJumbo = forceJumbo;
             dexOptions.allowAllInterfaceMethodInvokes = allowAllInterfaceMethodInvokes;
         }

--- a/app/src/main/java/mod/agus/jcoderz/dx/dex/DexOptions.java
+++ b/app/src/main/java/mod/agus/jcoderz/dx/dex/DexOptions.java
@@ -38,8 +38,8 @@ public final class DexOptions {
     */
     public boolean ALIGN_64BIT_REGS_IN_OUTPUT_FINISHER = ALIGN_64BIT_REGS_SUPPORT;
 
-    /** minimum SDK version targeted */
-    public int minSdkVersion = DexFormat.API_NO_EXTENDED_OPCODES;
+    /** target API level */
+    public int targetApiLevel = DexFormat.API_NO_EXTENDED_OPCODES;
 
     /** force generation of jumbo opcodes */
     public boolean forceJumbo = false;
@@ -63,17 +63,15 @@ public final class DexOptions {
      * @return string representing the dex file magic number
      */
     public String getMagic() {
-        return DexFormat.apiToMagic(minSdkVersion);
+        return DexFormat.apiToMagic(targetApiLevel);
     }
 
     /**
      * Checks whether an API feature is supported.
      * @param apiLevel the API level to test
-     * @return returns true if the current API level is at least sdkVersion
+     * @return returns true if the target API level is at least apiLevel
      */
     public boolean apiIsSupported(int apiLevel) {
-        // TODO: the naming here is awkward. Tooling may rely on the minSdkVersion,
-        // but it is referred to as API in DexFormat. Currently indistinguishable.
-        return minSdkVersion >= apiLevel;
+        return targetApiLevel >= apiLevel;
     }
 }


### PR DESCRIPTION
Renamed `minSdkVersion` in `DexOptions` to `targetApiLevel` and updated its occurrences throughout `Main` and `Simulator`. Removed the associated "awkward naming" TODO since the naming is now self-explanatory and matches `apiLevel` / API naming conventions. Tested the change ensuring successful compilation and passed tests.

---
*PR created automatically by Jules for task [2981377648824942285](https://jules.google.com/task/2981377648824942285) started by @itarunpatil*