### PR TITLE
Remove duplicate Java/Kotlin manager from DesignActivity menu

### DIFF
--- a/app/src/main/java/com/besome/sketch/design/DesignActivity.java
+++ b/app/src/main/java/com/besome/sketch/design/DesignActivity.java
@@ -537,10 +537,6 @@ public class DesignActivity extends BaseAppCompatActivity implements View.OnClic
             toViewCodeEditor();
             return true;
         });
-        bottomMenu.add(Menu.NONE, 8, Menu.NONE, "Java/Kotlin manager").setOnMenuItemClickListener(item -> {
-            toJavaManager();
-            return true;
-        });
         bottomMenu.add(Menu.NONE, 9, Menu.NONE, "Build signed APK").setOnMenuItemClickListener(item -> {
             showSignedApkBuildDialog();
             return true;


### PR DESCRIPTION
Removed the 'Java/Kotlin manager' option from the bottom menu in DesignActivity.java as it is already available elsewhere. The associated click listener adding it to the menu was removed.

---
*PR created automatically by Jules for task [12186486246962975006](https://jules.google.com/task/12186486246962975006) started by @itarunpatil*