### PR TITLE
Optimize unsignedLeb128Size calculation

### DIFF
--- a/app/src/main/java/mod/agus/jcoderz/dex/Leb128.java
+++ b/app/src/main/java/mod/agus/jcoderz/dex/Leb128.java
@@ -35,17 +35,10 @@ public final class Leb128 {
      * @return its write size, in bytes
      */
     public static int unsignedLeb128Size(int value) {
-        // TODO: This could be much cleverer.
-
-        int remaining = value >> 7;
-        int count = 0;
-
-        while (remaining != 0) {
-            remaining >>= 7;
-            count++;
+        if (value == 0) {
+            return 1;
         }
-
-        return count + 1;
+        return (31 - Integer.numberOfLeadingZeros(value)) / 7 + 1;
     }
 
     /**


### PR DESCRIPTION
The iterative loop for calculating the unsigned LEB128 size has been replaced with a more efficient implementation using `Integer.numberOfLeadingZeros`. This optimization avoids multiple shifts and branches, leveraging a platform-intrinsic method for determining the most significant bit.

Verification:
- Tested with values 0, 1, 127, 128, 16383, 16384, etc.
- Verified correct handling of 32-bit values with the high bit set (e.g., 0x80000000 and 0xFFFFFFFF).
- Confirmed that 0 correctly returns a size of 1.

---
*PR created automatically by Jules for task [11374159735492065762](https://jules.google.com/task/11374159735492065762) started by @itarunpatil*