### PR TITLE
Fix parameter descriptor index in LocalEntry

### DIFF
--- a/app/src/main/java/mod/agus/jcoderz/dx/dex/file/DebugInfoDecoder.java
+++ b/app/src/main/java/mod/agus/jcoderz/dx/dex/file/DebugInfoDecoder.java
@@ -284,7 +284,13 @@ public class DebugInfoDecoder {
                 le = new LocalEntry(0, true, curReg, -1, 0, 0);
             } else {
                 // TODO: Final 0 should be idx of paramType.getDescriptor().
-                le = new LocalEntry(0, true, curReg, nameIdx, 0, 0);
+                int descIdx = 0;
+                try {
+                    descIdx = file.getStringIds().indexOf(new CstString(paramType.getDescriptor()));
+                } catch (IllegalArgumentException ex) {
+                    /* tolerate not finding string */
+                }
+                le = new LocalEntry(0, true, curReg, nameIdx, descIdx, 0);
             }
 
             locals.add(le);


### PR DESCRIPTION
Resolves the TODO comment in `DebugInfoDecoder.java` by fetching the correct string index for the parameter's descriptor instead of using 0.

---
*PR created automatically by Jules for task [7764981044534411542](https://jules.google.com/task/7764981044534411542) started by @itarunpatil*