### PR TITLE
🧹 Optimize unsignedLeb128Size calculation

### DIFF
--- a/app/src/main/java/mod/agus/jcoderz/dex/Leb128.java
+++ b/app/src/main/java/mod/agus/jcoderz/dex/Leb128.java
@@ -35,17 +35,7 @@ public final class Leb128 {
      * @return its write size, in bytes
      */
     public static int unsignedLeb128Size(int value) {
-        // TODO: This could be much cleverer.
-
-        int remaining = value >> 7;
-        int count = 0;
-
-        while (remaining != 0) {
-            remaining >>= 7;
-            count++;
-        }
-
-        return count + 1;
+        return (31 - Integer.numberOfLeadingZeros(value)) / 7 + 1;
     }
 
     /**


### PR DESCRIPTION
🧹 Optimize unsignedLeb128Size calculation

What:
Replaced the iterative loop in `unsignedLeb128Size` with a bitwise formula using `Integer.numberOfLeadingZeros`.

Why:
This is an O(1) bit-twiddling optimization that avoids branching and iterative shifts. Also prevents a theoretical infinite loop if the function were ever provided a negative integer (because the prior loop used a signed right-shift `>>`).

Verification:
Manually compiled and verified the exact outputs across multiple integers including boundaries (0, 1, 127, 128, Max, Min). Also ran `javac` on the `mod.agus.jcoderz.dex` package to ensure no breakages.

Result:
Calculation is now strictly mathematical, safe from negative value loops, and computationally faster.

---
*PR created automatically by Jules for task [16137933525832996807](https://jules.google.com/task/16137933525832996807) started by @itarunpatil*