### PR TITLE
🧹 Delete .kotlin_module files in KotlinCompiler

### DIFF
--- a/app/src/main/java/mod/hey/studios/compiler/kotlin/KotlinCompiler.kt
+++ b/app/src/main/java/mod/hey/studios/compiler/kotlin/KotlinCompiler.kt
@@ -100,8 +100,15 @@ class KotlinCompiler(
         LogUtil.d(TAG, "kotlinc MessageCollector: $collector")
 
         // kotlinc generates some .kotlin_module files that make D8 fail,
-        // delete them for now (?) TODO
-        File(mClassOutput, "META-INF").deleteRecursively()
+        // delete them for now
+        mClassOutput.walk().filter { it.name.endsWith(".kotlin_module") }.forEach { it.delete() }
+
+        // Cleanup empty META-INF directory if it's now empty
+        File(mClassOutput, "META-INF").let {
+            if (it.exists() && it.isDirectory && it.list()?.isEmpty() == true) {
+                it.delete()
+            }
+        }
 
         if (collector.hasErrors()) {
             LogUtil.e(TAG, "Failed to compile Kotlin files")


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the deletion of `.kotlin_module` files generated by `kotlinc`. Previously, the entire `META-INF` directory was deleted. Now, only `.kotlin_module` files are targeted, and `META-INF` is removed only if it becomes empty.
💡 **Why:** This improves maintainability by being more surgical with file deletions, avoiding potential issues if other important metadata is ever placed in `META-INF`. It also resolves a TODO.
✅ **Verification:** Logic verified using standalone Java programs simulating the file system operations. Manual code review confirms the targeted approach is safer.
✨ **Result:** A more robust and cleaner Kotlin compilation process that specifically addresses the D8 failure cause without side effects.

---
*PR created automatically by Jules for task [15354325126881712451](https://jules.google.com/task/15354325126881712451) started by @itarunpatil*